### PR TITLE
(Docs) add missing documentation for building the rust filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# gets the rust nightly toolchain and support for wasm compilation
+rust-toolchain:
+	rustup toolchain install nightly
+	rustup target add wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ make
 
 Simulates handling authentication of requests at proxy level. Requests with a header `token` with value `hello` are accepted as authorized while the rest unauthorized. The actual authentication is handled by the Upstream server. Whenever the proxy recieves a request it extracts the `token` header and makes a request to the Upstream server which validates the token and returns a response.
 
-Deploy: 
+Buld and deploy:
 ```bash
 cd http-auth
-make deploy-filtered
+make run-filtered
 ```
 
 Test:
@@ -56,10 +56,10 @@ curl  -H "token":"world" 0.0.0.0:18000 -v # Unauthorized
 
 Collects simple metrics for every TCP packet and logs it.
 
-Deploy: 
+Build and deploy:
 ```bash
 cd tcp-metrics
-make deploy-filtered
+make run-filtered
 ```
 
 Test:
@@ -73,10 +73,10 @@ Check the logs for the metrics.
 
 Parses the contents of every TCP packet the proxy recieves and logs it.
 
-Deploy: 
+Build and deploy:
 ```bash
 cd tcp-packet-parse
-make deploy-filtered
+make run-filtered
 ```
 
 Test:
@@ -90,10 +90,10 @@ Check the logs for the packet contents.
 
 An example which depicts an singleton HTTP WASM service which does an HTTP call once every 2 seconds.
 
-Deploy: 
+Build and deploy:
 ```bash
 cd singleton-http-call
-make deploy-filtered
+make run-filtered
 ```
 
 Check the logs for the response of the request.
@@ -102,10 +102,10 @@ Check the logs for the response of the request.
 
 This example showcases communication between a WASM filter and a service via shared queue. It combines the `Singleton-HTTP-Call` and `TCP-Metrics` examples. The filter collects metrics and enqueues it onto the queue while the service dequeues it and sends it to upstream server where it is stored.
 
-Deploy: 
+Build and deploy:
 ```bash
 cd metrics-store
-make deploy-filtered
+make run-filtered
 ```
 
 Test:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 
 This repository contains WASM filters in rust exercising different features provided by envoy-wasm.
 
+## Get the Rust toolchain
+
+To compile Rust filters to WASM, the nightly toolchain and support for wasm compilation target is needed.
+In the project root directory, run:
+```bash
+make rust-toolchain
+```
+
 ## Upstream
 
 Upstream is a webserver which is used by few of the filters mentioned above. It provides a route for :

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ make run-filtered
 
 Test:
 ```bash
-curl  -H 0.0.0.0:18000 -v -d "request body"
+curl 0.0.0.0:18000 -v -d "request body"
 ```
 
 Check the logs for the metrics.
@@ -81,7 +81,7 @@ make run-filtered
 
 Test:
 ```bash
-curl  -H 0.0.0.0:18000 -v -d "request body"
+curl 0.0.0.0:18000 -v -d "request body"
 ```
 
 Check the logs for the packet contents.


### PR DESCRIPTION
Fixes #9

This PR adds:
* Instructions on getting the Rust toolchain ready for compiling the filters.
* Modifying the current deployment instructions to use `run-filtered` rule which saves the hassle of doing `make build`
* Some minor fixes to the curl commands being used as tests.

Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

NOTE: Commits to be squashed after review.