### PR TITLE
(build) update rust examples to use wasm-pack for compiling to wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,4 @@
 rust-toolchain:
 	rustup toolchain install nightly
 	rustup target add wasm32-unknown-unknown
+	cargo install wasm-pack

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ This repository contains WASM filters in rust exercising different features prov
 ## Get the Rust toolchain
 
 To compile Rust filters to WASM, the nightly toolchain and support for wasm compilation target is needed.
-In the project root directory, run:
+Make sure you have Rust and Cargo installed [using Rustup](https://www.rust-lang.org/tools/install).
+If you're on a *nix system (Unix, Linux, MacOS), in the project root directory, run:
 ```bash
 make rust-toolchain
 ```
+This will also install wasm-pack for you.
+Also, take a look at [installing wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) for OS other than *nix.
 
 ## Upstream
 

--- a/http-auth/Cargo.toml
+++ b/http-auth/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proxy-wasm = "0.1.0"
+wasm-bindgen = "0.2"

--- a/http-auth/Makefile
+++ b/http-auth/Makefile
@@ -1,12 +1,26 @@
-build:
-	cargo +nightly build --target=wasm32-unknown-unknown --release 
+# check wether compiled with wasm-pack
+ifeq ($(shell test -e ./pkg/http_auth_bg.wasm && echo -n y),y)
+	WASM_PATH=./pkg/http_auth_bg.wasm
+endif
+
+# a small optimized binary without debug info, useful for releases
+build: clean
+	wasm-pack build --release
+
+# a large binary with debug info and no optimizations, useful
+# while debugging
+build-unoptimized: clean
+	cargo +nightly build --target=wasm32-unknown-unknown --release
+
+# read more about building .wasm binaries here:
+# https://rustwasm.github.io/docs/wasm-pack/commands/build.html
 
 deploy:
-	docker-compose up --build --remove-orphans
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans
 
 # shows only the logs related to WASM filter/singleton 
 deploy-filtered:
-	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
 
 run: build deploy
 
@@ -14,3 +28,4 @@ run-filtered: build deploy-filtered
 
 clean:
 	cargo clean
+	rm -rf ./pkg

--- a/http-auth/docker-compose.yaml
+++ b/http-auth/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: envoy.Dockerfile
     volumes:
       - ./envoy.yaml:/etc/envoy.yaml
-      - ./target/wasm32-unknown-unknown/release/http_auth.wasm:/etc/http_auth.wasm
+      - ${WASM_PATH:-./target/wasm32-unknown-unknown/release/http_auth.wasm}:/etc/http_auth.wasm
     networks:
       - envoymesh
     expose:

--- a/metrics-store/Makefile
+++ b/metrics-store/Makefile
@@ -1,18 +1,37 @@
-build:
-	cd singleton-queue && cargo +nightly build --target=wasm32-unknown-unknown --release 
-	cd metrics-collector && cargo +nightly build --target=wasm32-unknown-unknown --release 
+# check wether compiled with wasm-pack
+ifeq ($(shell test -e ./metrics-collector/pkg/metrics_collector_bg.wasm && echo -n y),y)
+	METRICS_COLLECTOR_WASM=./metrics_collector/pkg/metrics_collector_bg.wasm
+endif
+ifeq ($(shell test -e ./singleton-queue/pkg/singleton_queue_bg.wasm && echo -n y),y)
+	SINGLETON_QUEUE_WASM=./singleton-queue/pkg/singleton_queue_bg.wasm
+endif
+
+# a small optimized binary without debug info, useful for releases
+build: clean
+	cd singleton-queue && wasm-pack build --release
+	cd metrics-collector && wasm-pack build --release
+
+build-unoptimized: clean
+	cd metrics-collector; \
+	cargo +nightly build --target=wasm32-unknown-unknown --release;
+	cd singleton-queue; \
+	cargo +nightly build --target=wasm32-unknown-unknown --release;
 
 deploy:
-	docker-compose up --build --remove-orphans
+	METRICS_COLLECTOR_WASM=$(METRICS_COLLECTOR_WASM) \
+	SINGLETON_QUEUE_WASM=$(SINGLETON_QUEUE_WASM) \
+	docker-compose up --build --remove-orphans;
 
 # shows only the logs related to WASM filter/singleton
 deploy-filtered:
-	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
+	METRICS_COLLECTOR_WASM=$(METRICS_COLLECTOR_WASM) \
+	SINGLETON_QUEUE_WASM=$(SINGLETON_QUEUE_WASM) \
+	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting";
 
 run: build deploy
 
 run-filtered: build deploy-filtered
 
 clean:
-	cd singleton-queue && cargo clean
-	cd metrics-collector && cargo clean
+	cd singleton-queue && cargo clean && rm -rf ./pkg
+	cd metrics-collector && cargo clean && rm -rf ./pkg

--- a/metrics-store/docker-compose.yaml
+++ b/metrics-store/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
       dockerfile: envoy.Dockerfile
     volumes:
       - ./envoy.yaml:/etc/envoy.yaml
-      - ./metrics-collector/target/wasm32-unknown-unknown/release/metrics_collector.wasm:/etc/metrics_collector.wasm
-      - ./singleton-queue/target/wasm32-unknown-unknown/release/singleton_queue.wasm:/etc/singleton_queue.wasm
+      - ${METRICS_COLLECTOR_WASM:-./metrics-collector/target/wasm32-unknown-unknown/release/metrics_collector.wasm}:/etc/metrics_collector.wasm
+      - ${SINGLETON_QUEUE_WASM:-./singleton-queue/target/wasm32-unknown-unknown/release/singleton_queue.wasm}:/etc/singleton_queue.wasm
     networks:
       - envoymesh
     expose:

--- a/metrics-store/metrics-collector/Cargo.toml
+++ b/metrics-store/metrics-collector/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 proxy-wasm = "0.1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 bincode = "1.0"
+wasm-bindgen = "0.2"

--- a/metrics-store/singleton-queue/Cargo.toml
+++ b/metrics-store/singleton-queue/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 proxy-wasm = "0.1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 bincode = "1.0"
+wasm-bindgen = "0.2"

--- a/singleton-http-call/Cargo.toml
+++ b/singleton-http-call/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proxy-wasm = "0.1.0"
+wasm-bindgen = "0.2"

--- a/singleton-http-call/Makefile
+++ b/singleton-http-call/Makefile
@@ -1,12 +1,24 @@
-build:
+# check wether compiled with wasm-pack
+ifeq ($(shell test -e ./pkg/singleton_http_call_bg.wasm && echo -n y),y)
+	WASM_PATH=./pkg/singleton_http_call_bg.wasm
+endif
+
+# a small optimized binary without debug info, useful for releases
+build: clean
+	wasm-pack build --release
+
+build-unoptimized: clean
 	cargo +nightly build --target=wasm32-unknown-unknown --release 
 
+# read more about building .wasm binaries here:
+# https://rustwasm.github.io/docs/wasm-pack/commands/build.html
+
 deploy:
-	docker-compose up --build --remove-orphans
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans
 
 # shows only the logs related to WASM filter/singleton
 deploy-filtered:
-	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
 
 run: build deploy
 
@@ -14,3 +26,4 @@ run-filtered: build deploy-filtered
 
 clean:
 	cargo clean
+	rm -rf ./pkg

--- a/singleton-http-call/docker-compose.yaml
+++ b/singleton-http-call/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: envoy.Dockerfile
     volumes:
       - ./envoy.yaml:/etc/envoy.yaml
-      - ./target/wasm32-unknown-unknown/release/singleton_http_call.wasm:/etc/singleton_http_call.wasm
+      - ${WASM_PATH:-./target/wasm32-unknown-unknown/release/singleton_http_call.wasm}:/etc/singleton_http_call.wasm
     networks:
       - envoymesh
     expose:

--- a/tcp-metrics/Cargo.toml
+++ b/tcp-metrics/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proxy-wasm = "0.1.0"
+wasm-bindgen = "0.2"

--- a/tcp-metrics/Makefile
+++ b/tcp-metrics/Makefile
@@ -1,12 +1,21 @@
-build:
+# check wether compiled with wasm-pack
+ifeq ($(shell test -e ./pkg/tcp_metrics_bg.wasm && echo -n y),y)
+	WASM_PATH=./pkg/tcp_metrics_bg.wasm
+endif
+
+# a small optimized binary without debug info, useful for releases
+build: clean
+	wasm-pack build --release
+
+build-unoptimized: clean
 	cargo +nightly build --target=wasm32-unknown-unknown --release 
 
 deploy:
-	docker-compose up --build --remove-orphans
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans
 
 # shows only the logs related to WASM filter/singleton
 deploy-filtered:
-	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
 
 run: build deploy
 
@@ -14,3 +23,4 @@ run-filtered: build deploy-filtered
 
 clean:
 	cargo clean
+	rm -rf ./pkg

--- a/tcp-metrics/docker-compose.yaml
+++ b/tcp-metrics/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: envoy.Dockerfile
     volumes:
       - ./envoy.yaml:/etc/envoy.yaml
-      - ./target/wasm32-unknown-unknown/release/tcp_metrics.wasm:/etc/tcp_metrics.wasm
+      - ${WASM_PATH:-./target/wasm32-unknown-unknown/release/tcp_metrics.wasm}:/etc/tcp_metrics.wasm
     networks:
       - envoymesh
     expose:

--- a/tcp-packet-parse/Cargo.toml
+++ b/tcp-packet-parse/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 proxy-wasm = "0.1.0"
+wasm-bindgen = "0.2"

--- a/tcp-packet-parse/Makefile
+++ b/tcp-packet-parse/Makefile
@@ -1,12 +1,26 @@
-build:
-	cargo +nightly build --target=wasm32-unknown-unknown --release 
+# check wether compiled with wasm-pack
+ifeq ($(shell test -e ./pkg/tcp_packet_parse_bg.wasm && echo -n y),y)
+	WASM_PATH=./pkg/tcp_packet_parse_bg.wasm
+endif
+
+# a small optimized binary without debug info, useful for releases
+build: clean
+	wasm-pack build --release
+
+# a large binary with debug info and no optimizations, useful
+# while debugging
+build-unoptimized: clean
+	cargo +nightly build --target=wasm32-unknown-unknown --release
+
+# read more about building .wasm binaries here:
+# https://rustwasm.github.io/docs/wasm-pack/commands/build.html
 
 deploy:
-	docker-compose up --build --remove-orphans
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans
 
-# shows only the logs related to WASM filter/singleton
+# shows only the logs related to WASM filter/singleton 
 deploy-filtered:
-	docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
+	WASM_PATH=$(WASM_PATH) docker-compose up --build --remove-orphans | grep "\[wasm\]\|Starting"
 
 run: build deploy
 
@@ -14,3 +28,4 @@ run-filtered: build deploy-filtered
 
 clean:
 	cargo clean
+	rm -rf ./pkg

--- a/tcp-packet-parse/docker-compose.yaml
+++ b/tcp-packet-parse/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: envoy.Dockerfile
     volumes:
       - ./envoy.yaml:/etc/envoy.yaml
-      - ./target/wasm32-unknown-unknown/release/tcp_packet_parse.wasm:/etc/tcp_packet_parse.wasm
+      - ${WASM_PATH:-./target/wasm32-unknown-unknown/release/tcp_packet_parse.wasm}:/etc/tcp_packet_parse.wasm
     networks:
       - envoymesh
     expose:


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR Fixes #12 

**Notes for Reviewers**
This PR updates the build process for the example Rust filters. All the changes are similar in nature for each example and can be summarized as:

- update the build rule to use wasm-pack for optimized binaries
- update dockerfile and makefile to mount docker volume according to
  build rule
- add wasm-bindgen dependency


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Wasm-Filters! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->