### PR TITLE
Proposing an upgrade on upstream from `go1.13` to `go1.19`

### DIFF
--- a/upstream/Dockerfile
+++ b/upstream/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.13.5 as bd
+# syntax=docker/dockerfile:1
+
+FROM golang:1.19.1 as bd
 WORKDIR /github.com/layer5io/wasm-upstream
 ADD . .
 RUN GOPROXY=direct GOSUMDB=off go build -a -o /upstream .

--- a/upstream/go.mod
+++ b/upstream/go.mod
@@ -1,0 +1,3 @@
+module github.com/layer5io/wasm-filters/upstream
+
+go 1.19

--- a/upstream/main.go
+++ b/upstream/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -10,7 +10,7 @@ var gldata = ""
 
 func store(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Antonette Caldwell <pullmana8@gmail.com>

**Description**

This PR does not a current issue.

**Notes for Reviewers**

Dockerfile is using `go1.13` which is EOL, and I am proposing to use `go1.19` which is what I currently have installed on my development machine, however it should still work at `go1.17` and `go1.18`.

The `ioutil` has been deprecated as of go1.6, which has been changed to `io`.

This file should be updated before updating the rest of content in the repository.

**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Wasm-Filters! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->