### PR TITLE
Refactor badge section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@
       </picture>
 </p>
 
-![GitHub contributors](https://img.shields.io/github/contributors/layer5io/layer5.svg)
-[![GitHub](https://img.shields.io/github/license/layer5io/layer5.svg)](https://github.com/layer5io/wasm-filters/blob/master/LICENSE) 
-![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/layer5/help%20wanted.svg?color=%23DDDD00)
-[![Slack](https://img.shields.io/badge/Slack-@layer5.svg?logo=slack)](http://slack.layer5.io)
-![Twitter Follow](https://img.shields.io/twitter/follow/layer5.svg?label=Follow&style=social)
+<p align="center">
+<a href="https://github.com/layer5io/layer5/graphs/contributors" alt="GitHub contributors">
+<img src="https://img.shields.io/github/contributors/layer5io/layer5.svg" /></a>
+<a href="https://github.com/layer5io/wasm-filters/blob/master/LICENSE" alt="License">
+<img src="https://img.shields.io/github/license/layer5io/layer5.svg" /></a>
+<a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+(org%3Alayer5io+OR+org%3Ameshery+OR+org%3Alayer5labs+OR+org%3Aservice-mesh-performance+OR+org%3Aservice-mesh-patterns+OR+org%3Ameshery-extensions)+label%3A%22help+wanted%22" alt="Help wanted issues">
+<img src="https://img.shields.io/github/issues/layer5io/layer5/help%20wanted.svg?color=%23DDDD00" /></a>
+<a href="http://slack.layer5.io" alt="Slack">
+<img src="https://img.shields.io/badge/Slack-@layer5.svg?logo=slack" /></a>
+<a href="https://twitter.com/layer5" alt="Twitter Follow">
+<img src="https://img.shields.io/twitter/follow/layer5.svg?label=Follow&style=social" /></a>
+</p>
 
 # WebAssembly Filters for Envoy
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See all community meeting details --> https://meet.layer5.io
 ## Join the Community!
 
 <a name="contributing"></a><a name="community"></a>
-Our projects are community-built and welcome collaboration. 👍 Be sure to see the <a href="https://docs.google.com/document/d/17OPtDE_rdnPQxmk2Kauhm3GwXF1R5dZ3Cj8qZLKdo5E/edit">Layer5 Community Welcome Guide</a> for a tour of resources available to you and jump into our <a href="http://slack.layer5.io">Slack</a>!
+Our projects are community-built and welcome collaboration. 👍 Be sure to see the <a href="https://layer5.io/community/newcomers">Layer5 Community Welcome Guide</a> for a tour of resources available to you and jump into our <a href="http://slack.layer5.io">Slack</a>!
 
 <a href="https://slack.meshery.io">
 


### PR DESCRIPTION
Updated badge links and added HTML formatting for better display.

**Description**
Previously after clicking on badges, another webpage having its image appears:
<img width="1503" height="861" alt="image" src="https://github.com/user-attachments/assets/eef5cfd1-635d-4a19-9017-04b847130a87" />

After (now it directly opens the link):
<img width="1508" height="853" alt="image" src="https://github.com/user-attachments/assets/9bdc90e5-cef3-4e6b-bdfb-faa087338191" />


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
